### PR TITLE
Fix issues with built-in shaders

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"sync"
 
+	"github.com/dianelooney/gggv/internal/logs"
+
 	"github.com/dianelooney/gggv/internal/opengl"
 )
 
@@ -71,7 +73,10 @@ func (d *D) SetShaderProgram(name, program string) {
 
 func (d *D) AddProgram(name, vShader, fShader string) {
 	d.Schedule(func() {
-		d.Scene.LoadProgram(name, vShader, fShader)
+		err := d.Scene.LoadProgram(name, vShader, fShader)
+		if err != nil {
+			logs.Error("Unable to load program", name, err)
+		}
 	})
 }
 

--- a/shaders/frag/filt.grayscale.glsl
+++ b/shaders/frag/filt.grayscale.glsl
@@ -1,7 +1,7 @@
-
 #version 330
 
 in vec2 fragTexCoord;
+uniform sampler2D tex0;
 out vec4 outputColor;
 
 void main() {

--- a/shaders/frag/filt.randomDither.glsl
+++ b/shaders/frag/filt.randomDither.glsl
@@ -13,22 +13,22 @@ float gold_noise(in vec2 coordinate, in float seed){
     return fract(tan(distance(coordinate*(seed+PHI), vec2(PHI, PI)))*SQ2);
 }
 
-vec4 randither(vec4 input, vec2 co, float seed){
-    vec3 thresh = vec3(gold_noise(co+input.rg,seed),gold_noise(co+input.br,seed),gold_noise(co-input.rb,seed));
-    vec4 ret = input;
-    if(input.r < thresh.r){
+vec4 randither(vec4 inColor, vec2 co, float seed){
+    vec3 thresh = vec3(gold_noise(co+inColor.rg,seed),gold_noise(co+inColor.br,seed),gold_noise(co-inColor.rb,seed));
+    vec4 ret = inColor;
+    if(inColor.r < thresh.r){
         ret.r = 0;
     }
     else{
         ret.r = 1;
     }
-    if(input.g < thresh.g){
+    if(inColor.g < thresh.g){
         ret.g = 0;
     }
     else{
         ret.g = 1;
     }
-    if(input.b < thresh.b){
+    if(inColor.b < thresh.b){
         ret.b = 0;
     }
     else{
@@ -40,6 +40,6 @@ vec4 randither(vec4 input, vec2 co, float seed){
 
 void main(void)
 {
-    outputColor=texture(tex0,fragTexCoord);
+    outputColor = texture(tex0,fragTexCoord);
     outputColor = randither(outputColor, fragTexCoord, time);//randither(outputColor);
 }


### PR DESCRIPTION
```
panic: [GLFShaderCompile] shader compilation failed: ERROR: 0:16: 'input' : Reserved word. 
ERROR: 0:16: 'input' : syntax error: syntax error

===== SOURCE =====
#version 330

uniform float time;
uniform sampler2D tex0;

in vec2 fragTexCoord;
out vec4 outputColor;

float PHI = 1.61803398874989484820459 * 00000.1; // Golden Ratio   
float PI  = 3.14159265358979323846264 * 00000.1; // PI
float SQ2 = 1.41421356237309504880169 * 10000.0; // Square Root of Two
float gold_noise(in vec2 coordinate, in float seed){
    return fract(tan(distance(coordinate*(seed+PHI), vec2(PHI, PI)))*SQ2);
}

vec4 randither(vec4 input, vec2 co, float seed){
    vec3 thresh = vec3(gold_noise(co+input.rg,seed),gold_noise(co+input.br,seed),gold_noise(co-input.rb,seed));
    vec4 ret = input;
    if(input.r < thresh.r){
        ret.r = 0;
    }
    else{
        ret.r = 1;
    }
    if(input.g < thresh.g){
        ret.g = 0;
    }
    else{
        ret.g = 1;
    }
    if(input.b < thresh.b){
        ret.b = 0;
    }
    else{
        ret.b = 1;
    }

    return ret;
}

void main(void)
{
    outputColor = texture(tex0,fragTexCoord);
    outputColor = randither(outputColor, fragTexCoord, time);//randither(outputColor);
    outputColor = vec4(0.5, 0.5, 0.5, 0.5);
}

```

And

```
panic: [GLFShaderCompile] shader compilation failed: ERROR: 0:7: Use of undeclared identifier 'tex0'

===== SOURCE =====
#version 330

in vec2 fragTexCoord;
out vec4 outputColor;

void main() {
    outputColor = texture(tex0, fragTexCoord);
    float val = (outputColor.r + outputColor.g + outputColor.b)/3;
    outputColor = vec4(val,val,val,1);
    outputColor = vec4(0.5);
}

```