### PR TITLE
Some more CI tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,31 @@ commands:
           paths:
             - /go/pkg
 
+  install-deps-windows:
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: choco install mingw pkgconfiglite
+      - run:
+          name: Setup pkg-config stubs
+          command: ./build/windows/configure.sh
+      # - run:
+      #     name: Install Portaudio
+      #     command: |
+      #       curl http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz > /tmp/portaudio.tgz
+      #       7z x /tmp/portaudio.tgz -o/tmp/
+      #       7z x /tmp/portaudio.tar -o/tmp/
+      #       cd /tmp/portaudio && ./configure && make install
+      - run:
+          name: Install FFMPEG-dev
+          command: |
+            curl https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-latest-win64-dev.zip > /tmp/ffmpeg-latest-win64-dev.zip
+            unzip /tmp/ffmpeg-latest-win64-dev.zip -d /tmp/
+      - run:
+          name: Install go 1.13
+          command: choco install golang
+
 jobs:
   vet:
     executor: base-linux
@@ -57,35 +82,9 @@ jobs:
     executor:
       name: win/vs2019
       shell: bash.exe
+
     steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: choco install mingw pkgconfiglite
-      - run:
-          name: Setup pkg-config stubs
-          command: ./build/windows/configure.sh
-      # - run:
-      #     name: Download Portaudio
-      #     command: curl http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz > /tmp/portaudio.tgz
-      # - run:
-      #     name: Extract Portaudio (1)
-      #     command: 7z x /tmp/portaudio.tgz -o/tmp/
-      # - run:
-      #     name: Extract Portaudio (2)
-      #     command: 7z x /tmp/portaudio.tar -o/tmp/
-      # - run:
-      #     name: Install Portaudio
-      #     command: cd /tmp/portaudio && ./configure && make install
-      - run:
-          name: Download FFMPEG-dev
-          command: curl https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-latest-win64-dev.zip > /tmp/ffmpeg-latest-win64-dev.zip
-      - run:
-          name: Extract FFMPEG-dev
-          command: unzip /tmp/ffmpeg-latest-win64-dev.zip -d /tmp/
-      - run:
-          name: Install go 1.13
-          command: choco install golang
+      - install-deps-windows
       - run:
           name: Build Daemon
           command: go build -o=daemon.exe cmd/daemon/main.go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
             unzip /tmp/ffmpeg-latest-win64-dev.zip -d /tmp/
       - run:
           name: Install go 1.13
-          command: choco install golang
+          command: choco install golang --force
 
 jobs:
   vet:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,29 +5,44 @@ orbs:
   win: circleci/windows@1.0.0
   docker: circleci/docker@0.5.20
 
+executors:
+  base-linux:
+    docker:
+      - image: circleci/golang:1.13
+    working_directory: /go/src/github.com/dianelooney/gggv
+
+commands:
+  install-deps:
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-pkg-cache
+      - run: sudo ./build/gggv/configure.sh
+      - run: go get -v -t -d ./...
+      - save_cache:
+          key: v1-pkg-cache
+          paths:
+            - /go/pkg
+
 jobs:
   vet:
-    docker:
-      - image: diane/gggv-base:latest
-    environment:
-      CGO_CFLAGS: -w
-    working_directory: /go/src/github.com/dianelooney/gggv
+    executor: base-linux
     steps:
-      - checkout
-      - run: go get -v -t -d ./...
+      - install-deps
       - run: go vet -unsafeptr=false $(go list ./... | grep -v /wrappers/)
   test:
-    docker:
-      - image: diane/gggv-base:latest
+    executor: base-linux
     environment:
       CGO_CFLAGS: -w
-    working_directory: /go/src/github.com/dianelooney/gggv
+      COV_FILE: /tmp/coverage/c.out
     steps:
-      - checkout
-      - run: go get -v -t -d ./...
-      - run: mkdir /tmp/coverage
-      - run: go test -v ./... -coverprofile=/tmp/coverage/c.out
-      - run: go tool cover -html=/tmp/coverage/c.out -o /tmp/coverage/c.html
+      - install-deps
+      - run:
+          command: |
+            mkdir $(dirname ${COV_FILE})
+            go test -v ./... -coverprofile=${COV_FILE}
+      - run: go tool cover -html=${COV_FILE} -o ${COV_FILE/%.out/.html}
       - store_artifacts:
           path: /tmp/coverage
   #     - codecov/upload:

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[*.sh]
+indent_style = tab

--- a/build/gggv/configure.sh
+++ b/build/gggv/configure.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+libs=(
+	# github.com/ggordonklaus/portaudio
+	portaudio19-dev
+
+	# github.com/go-gl/gl
+	libgl1-mesa-dev
+	xorg-dev
+
+	# github.com/giorgisio/goav
+	libavcodec-dev
+	libavformat-dev
+	libavutil-dev
+	libavfilter-dev
+	libavdevice-dev
+	libswresample-dev
+	libswscale-dev
+)
+
+apt-get install --no-install-recommends ${libs[@]}

--- a/build/windows/base.pc
+++ b/build/windows/base.pc
@@ -1,4 +1,3 @@
-
 exec_prefix=${prefix}
 includedir=${prefix}/include
 libdir=${exec_prefix}/lib

--- a/build/windows/configure.sh
+++ b/build/windows/configure.sh
@@ -1,12 +1,30 @@
-mkdir $PKG_CONFIG_PATH
+set -euo pipefail
 
+mkdir -p $PKG_CONFIG_PATH
 
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libavcodec" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libavcodec.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libavfilter" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libavfilter.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libavutil" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libavutil.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libswscale" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libswscale.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libavdevice" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libavdevice.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libavformat" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libavformat.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=libswresample" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/libswresample.pc;
-( echo "prefix=/tmp/ffmpeg-latest-win64-dev"; echo "name=swresample" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/swresample.pc;
+declare -A libs
+
+# github.com/giorgisio/goav
+libs["ffmpeg-latest-win64-dev"]="
+	libavcodec
+	libavfilter
+	libavutil
+	libavdevice
+	libavformat
+	libswscale
+	libswresample
+	swresample
+"
+
+for prefix in "${!libs[@]}"; do
+	for lib in ${libs[$prefix]}; do
+		cat <<-EOM >${PKG_CONFIG_PATH}/${lib}.pc
+			prefix=/tmp/${prefix}
+			name=${lib}
+
+			$(<build/windows/base.pc)
+		EOM
+	done
+done
+
 # ( echo "prefix=/tmp/portaudio"; echo "name=portaudio-2.0" ; cat build/windows/base.pc ) > $PKG_CONFIG_PATH/portaudio-2.0.pc;


### PR DESCRIPTION
Taking advantage of some more CircleCI features and bash voodoo for fun and profit.

- Is `ffmpeg` only a runtime dependency? All of the tests pass without it, so I'm assuming having the `libav*` stuff installed is sufficient for the package itself.
- Are you using the `gggv-base` image for anything other than CI and building the daemon image?
- Is it possible to cross-compile a statically linked binary? If that's the case, you wouldn't need to build a Windows image/version during CI. Although you could still make a runtime image with `ffmpeg` and the binary injected.

Lemme know before merging and I'll make some changes there as well as update the README. Unfortunately, I don't really have a way to test the Windows stuff other than sanity checking the files that get created (since it looks like the CI steps aren't being run on my PRs)